### PR TITLE
Chore/#7: 데이터베이스를 PostgreSQL로 변경

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="daylily.sqlite" uuid="6411bb57-3c63-4bfe-a922-366522b9fd25">
-      <driver-ref>sqlite.xerial</driver-ref>
+    <data-source source="LOCAL" name="daylily-db@localhost" uuid="65d45be6-427f-49d8-a71e-991378279e9f">
+      <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
-      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
-      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/daylily.sqlite</jdbc-url>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5432/daylily-db</jdbc-url>
       <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,8 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-    // SQLite + JPA
-    implementation("org.xerial:sqlite-jdbc:3.50.2.0")
-    implementation("org.hibernate.orm:hibernate-community-dialects:7.0.6.Final")
+    // PostgreSQL + JPA
+    implementation("org.postgresql:postgresql:42.7.7")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     // Lombok

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,0 +1,23 @@
+name: daylily-dev
+
+services:
+  # PostgreSQL database
+  db:
+    image: postgres:alpine
+    ports:
+      - "5432:5432"
+    restart: always
+    shm_size: 128mb
+    environment:
+      - POSTGRES_USER=daylily
+      - POSTGRES_PASSWORD=daylily
+      - POSTGRES_DB=daylily-db
+
+  # Tool for managing the database
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - "8081:8080"
+    depends_on:
+      - db

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,15 +2,10 @@ spring.application.name=daylily-spring
 logging.level.com.daylily=DEBUG
 
 # Database Configuration
-spring.datasource.url=jdbc:sqlite:daylily.sqlite
-spring.datasource.driver-class-name=org.sqlite.JDBC
-
-# Reference: https://jilles.me/setting-up-spring-jdbc-and-sqlite-with-write-ahead-logging-mode/
-spring.datasource.hikari.connection-init-sql=\
-    PRAGMA journal_mode=WAL;\
-    PRAGMA synchronous=NORMAL;\
-    PRAGMA cache_size=-10000;\
-    PRAGMA temp_store=MEMORY;
+spring.datasource.url=${DAYLILY_DB_URL:jdbc:postgresql://localhost:5432/daylily-db}
+spring.datasource.username=${DAYLILY_DB_USER:daylily}
+spring.datasource.password=${DAYLILY_DB_PASSWORD:daylily}
+spring.datasource.driver-class-name=org.postgresql.Driver
 spring.sql.init.mode=always
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
#7 

## 작업내역

프로젝트 데이터베이스를 `SQLite`에서 `PostgreSQL`로 변경했습니다.

이에 따라 팀원분들이 로컬에서 실행할 수 있도록 `docker-compose-dev.yaml` 파일을 추가했습니다. 따라서 Docker Desktop이 설치된 상태라면 DB를 바로 Docker에서 구동하며 개발할 수 있습니다.