### PR TITLE
bug/#23: Manifest JSON 생성 필드 내용 수정

### DIFF
--- a/src/main/java/com/daylily/domain/github/dto/manifest/Manifest.java
+++ b/src/main/java/com/daylily/domain/github/dto/manifest/Manifest.java
@@ -68,22 +68,23 @@ public record Manifest(
                 true
         );
 
+        var url = manifestRequest.url();
         return Manifest.builder()
                 .name(manifestRequest.name())
-                .url(manifestRequest.url())
+                .url(url)
                 .hookAttributes(webhookAttributes)
-                .redirectUrl(manifestRequest.url() + "/api/app/manifest/redirect") // GitHubAppController::createGitHubApp
-                .callbackUrls(List.of("/"))
+                .redirectUrl(url + "/api/app/manifest/redirect") // GitHubAppController::createGitHubApp
+                .callbackUrls(List.of(url + "/api/app/manifest/redirect"))
                 .setupUrl("")
                 .description(manifestRequest.description())
                 .isPublic(manifestRequest.isPublic())
-                .defaultEvents(List.of("pull_request", "installation", "installation_repositories"))
+                .defaultEvents(List.of("pull_request"))
                 .defaultPermissions(Map.of(
                         "contents", "read",
                         "pull_requests", "write",
                         "metadata", "read"
                 ))
-                .requestOauthOnInstall(true)
+                .requestOauthOnInstall(false)
                 .setupOnUpdate(false)
                 .build();
     }


### PR DESCRIPTION
## 작업내용

잘못된 Manifest JSON 필드 내용으로 GitHub에서 앱 등록이 안되던 문제를 수정했습니다.

- `callback_url` -> `redirect_url`과 동일하게 변경
  - GitHub에 의하면 `redirect_url`을 포함하지 않으면 `callback_url`의 첫번째 url을 쓴다고는 하는데 일단 넣었습니다.
- `defaultEvents` 수정: `installation, installation_repositories`는 기본 이벤트라 명시하지 않아도 됩니다.
- `requestOauthOnInstall`를 `false`로 수정
  - 아마 `true`로 두면 앱 설치후 별도의 핸들링 로직이 있어야 했던것 같은데 일단 `false`로 처리했습니다.