### PR TITLE
feat: IAT 토큰 발급 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,11 +72,18 @@ dependencies {
 
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("com.auth0:java-jwt:4.4.0")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5") // JSON 직렬화용
 
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
     // Caffeine in memory Cache
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.2")
+
+    // Pem key Parsing
+    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.grpc:spring-grpc-test")

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -31,7 +31,7 @@ services:
       - "--entrypoints.web.address=:80"
     ports:
       - "80:80"
-      - "8080:8080"
+      - "8081:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 volumes:

--- a/src/main/java/com/daylily/domain/github/controller/GitHubAppController.java
+++ b/src/main/java/com/daylily/domain/github/controller/GitHubAppController.java
@@ -3,6 +3,8 @@ package com.daylily.domain.github.controller;
 import com.daylily.domain.github.dto.manifest.ManifestRequest;
 import com.daylily.domain.github.dto.manifest.ManifestResponse;
 import com.daylily.domain.github.service.GitHubAppService;
+import com.daylily.domain.github.web.dto.InstallationAccessTokenReq;
+import com.daylily.domain.github.web.dto.InstallationAccessTokenRes;
 import com.daylily.global.response.SuccessResponse;
 import com.daylily.global.util.StateStore;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,5 +57,12 @@ public class GitHubAppController {
         return ResponseEntity.status(HttpStatus.SEE_OTHER)
                 .location(installURI)
                 .build();
+    }
+
+    @PostMapping("/installation-token")
+    public ResponseEntity<?> createToken(@RequestBody InstallationAccessTokenReq req) {
+        System.out.println("..");
+        InstallationAccessTokenRes iat = service.getAccessToken(req.getInstallationId());
+        return ResponseEntity.ok(iat);
     }
 }

--- a/src/main/java/com/daylily/domain/github/repository/GitHubAppRepository.java
+++ b/src/main/java/com/daylily/domain/github/repository/GitHubAppRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface GitHubAppRepository extends JpaRepository<GitHubApp, Long> {
 
     Optional<GitHubApp> findByAppId(Long appId);
+
+    Optional<GitHubApp> findByInstallationId(long installationId);
 }

--- a/src/main/java/com/daylily/domain/github/service/GitHubAppService.java
+++ b/src/main/java/com/daylily/domain/github/service/GitHubAppService.java
@@ -2,6 +2,7 @@ package com.daylily.domain.github.service;
 
 import com.daylily.domain.github.dto.manifest.ManifestRequest;
 import com.daylily.domain.github.dto.manifest.ManifestResponse;
+import com.daylily.domain.github.web.dto.InstallationAccessTokenRes;
 
 import java.net.URI;
 
@@ -21,4 +22,6 @@ public interface GitHubAppService {
      * @param rawPayload 웹훅 페이로드
      */
     void handleGitHubAppInstallation(String rawPayload);
+
+    InstallationAccessTokenRes getAccessToken(long installationId);
 }

--- a/src/main/java/com/daylily/domain/github/web/dto/InstallationAccessTokenReq.java
+++ b/src/main/java/com/daylily/domain/github/web/dto/InstallationAccessTokenReq.java
@@ -1,0 +1,10 @@
+package com.daylily.domain.github.web.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InstallationAccessTokenReq {
+    Long installationId;
+}

--- a/src/main/java/com/daylily/domain/github/web/dto/InstallationAccessTokenRes.java
+++ b/src/main/java/com/daylily/domain/github/web/dto/InstallationAccessTokenRes.java
@@ -1,0 +1,11 @@
+package com.daylily.domain.github.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public record InstallationAccessTokenRes(
+        String token,
+        @JsonProperty("expires_at") Instant expiresAt
+        ) {
+}

--- a/src/main/java/com/daylily/global/config/GitHubConfig.java
+++ b/src/main/java/com/daylily/global/config/GitHubConfig.java
@@ -4,11 +4,22 @@ import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
 
 @Configuration
 public class GitHubConfig {
+
+    // IAT(Install Access Token)을 가져오기 위한 WebClient 빌더
+    @Bean
+    public WebClient githubWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://api.github.com")
+                .defaultHeader("Accept", "application/vnd.github+json")
+                .defaultHeader("X-GitHub-Api-Version", "2022-11-28")
+                .build();
+    }
 
     @Bean
     public GitHub gh() {

--- a/src/main/java/com/daylily/global/config/SecurityConfig.java
+++ b/src/main/java/com/daylily/global/config/SecurityConfig.java
@@ -4,15 +4,13 @@ import com.daylily.domain.auth.handler.OAuth2AuthenticationSuccessHandler;
 import com.daylily.domain.auth.service.UserService;
 import com.daylily.global.exception.CustomAccessDeniedHandler;
 import com.daylily.global.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -24,32 +22,43 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
-        return config.getAuthenticationManager();
-    }
-
-    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/error").permitAll()
+                // API만 쓰는 동안엔 세션 끔
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/error",
+                                "/health", "/actuator/**",
+                                "/api/app/manifest/**",
+                                "/api/app/callback",
+                                "/api/webhook",
+                                // IAT 발급 테스트(임시 허용)
+                                "/api/app/installation-token"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .oauth2Login(oauth -> oauth
-                        .successHandler(oAuth2AuthenticationSuccessHandler()) // JSON 응답 전용
+                // 미인증 시 리다이렉트 말고 401 JSON을 반환
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) -> {
+                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            res.setContentType("application/json");
+                            res.getWriter().write("{\"error\":\"unauthorized\"}");
+                        })
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
-                .exceptionHandling(ex -> ex.accessDeniedHandler(accessDeniedHandler))
+                // 브라우저에서 실제 OAuth2 로그인 쓸 때만 동작
+                .oauth2Login(oauth -> oauth.successHandler(oAuth2AuthenticationSuccessHandler()))
+                // 불필요한 기본 폼/로그아웃 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
                 .build();
     }
+
     @Bean
     public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
-
         return new OAuth2AuthenticationSuccessHandler(userService, jwtProvider);
     }
 }
+

--- a/src/main/java/com/daylily/global/jwt/JwtProvider.java
+++ b/src/main/java/com/daylily/global/jwt/JwtProvider.java
@@ -1,15 +1,25 @@
 package com.daylily.global.jwt;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
-import java.security.Key;
+import java.io.StringReader;
+import java.security.*;
+import java.security.interfaces.RSAPrivateKey;
+import java.time.Instant;
 import java.util.Date;
+
 
 @Component
 public class JwtProvider {
@@ -39,5 +49,64 @@ public class JwtProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
+
+    public String createAppJwt(long appId, String pem) {
+        RSAPrivateKey key = readPrivateKeyFromPem(pem);
+
+        Instant now = Instant.now();
+        Date iat = Date.from(now.minusSeconds(60));     // 클럭 드리프트 버퍼
+        Date exp = Date.from(now.plusSeconds(9 * 60));  // 10분 미만
+
+        return JWT.create()
+                .withIssuer(String.valueOf(appId))
+                .withIssuedAt(iat)
+                .withExpiresAt(exp)
+                .sign(Algorithm.RSA256(null, key));
+    }
+
+    private RSAPrivateKey readPrivateKeyFromPem(String pem) {
+        try {
+            Security.addProvider(new BouncyCastleProvider());
+
+            // DB에는 본문만 저장되어 있으므로 헤더가 없으면 PKCS#8/PKCS#1 두 가지로 감싸서 시도
+            String normalized = pem.strip();
+
+            if (!normalized.contains("BEGIN")) {
+                String body = normalized.replaceAll("\\s+", "");
+                // 64자 줄바꿈을 적당히 넣어주면 파서가 더 잘 읽습니다
+                String lines = body.replaceAll("(.{64})", "$1\n");
+
+                // 1) PKCS#8
+                String pkcs8 = "-----BEGIN PRIVATE KEY-----\n" + lines + "\n-----END PRIVATE KEY-----\n";
+                try { return parsePem(pkcs8); } catch (Exception ignore) {}
+
+                // 2) PKCS#1 (RSA)
+                String pkcs1 = "-----BEGIN RSA PRIVATE KEY-----\n" + lines + "\n-----END RSA PRIVATE KEY-----\n";
+                return parsePem(pkcs1);
+            }
+
+            return parsePem(normalized);
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid GitHub App PEM", e);
+        }
+    }
+
+    private RSAPrivateKey parsePem(String pemWithHeaders) throws Exception {
+        try (PEMParser parser = new PEMParser(new StringReader(pemWithHeaders))) {
+            Object obj = parser.readObject();
+            var conv = new JcaPEMKeyConverter().setProvider("BC");
+
+            PrivateKey pk;
+            if (obj instanceof PrivateKeyInfo pki) {
+                pk = conv.getPrivateKey(pki);             // PKCS#8
+            } else if (obj instanceof PEMKeyPair kp) {
+                pk = conv.getKeyPair(kp).getPrivate();    // PKCS#1
+            } else {
+                throw new IllegalStateException("Unsupported PEM type: " + obj);
+            }
+            return (RSAPrivateKey) pk;
+        }
+    }
+
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.datasource.password=${DAYLILY_DB_PASSWORD:password}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.sql.init.mode=always
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 
 # swagger-ui configuration
 springdoc.swagger-ui.path=docs


### PR DESCRIPTION
## 작업내용

- 사용자가 Github App install 시, 프론트로부터 installation id가 날아온다는 가정 하에 Install Access Token 생성하도록 임시 기능 구현했습니다. 향후 callback이 제대로 돌아올 경우 수정하도록 하겠습니다.

## 할 일
- Oauth2 로직을 수정할 예정입니다.  플로우는 아래와 같습니다.
1. OAuth 로그인으로 user.id 식별
2. DB의 설치 이력으로 installation_id 찾기
3. 서버가 IAT 발급
4. API 실행