### PR TITLE
feat: DB 기반 커스텀 ClientRegistrationRepository 구현

### DIFF
--- a/src/main/java/com/daylily/domain/github/entity/GitHubApp.java
+++ b/src/main/java/com/daylily/domain/github/entity/GitHubApp.java
@@ -1,6 +1,7 @@
 package com.daylily.domain.github.entity;
 
 import com.daylily.global.entity.AesGcmStringConverter;
+import com.daylily.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GitHubApp {
+public class GitHubApp extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/daylily/domain/github/repository/DynamicClientRegistrationRepository.java
+++ b/src/main/java/com/daylily/domain/github/repository/DynamicClientRegistrationRepository.java
@@ -1,0 +1,64 @@
+package com.daylily.domain.github.repository;
+
+
+import com.daylily.domain.github.entity.GitHubApp;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.stereotype.Component;
+
+/**
+ * DB에 저장된 GitHub App 자격증명(client_id/secret)을
+ * 런타임 시 읽어 OAuth2 ClientRegistration을 동적으로 생성
+ *
+ * properties/.env 하드코딩 불필요
+ * 최신(updatedAt DESC) 1건만 사용
+ * 팀장 1명만 github_app table에 등록되는 거니까.. 걍 Spring data jpa 신경안씀
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DynamicClientRegistrationRepository implements ClientRegistrationRepository {
+
+    private static final String REGISTRATION_ID = "github-app";
+
+    private final GitHubAppRepository repo;
+
+    /**
+     * Spring Security가 OAuth2 로그인 시 이 메서드를 호출해
+     * 주어진 registrationId에 해당하는 ClientRegistration을 요청한다.
+     */
+    @Override
+    @Transactional
+    public ClientRegistration findByRegistrationId(String registrationId) {
+        log.debug("[OAuth] findByRegistrationId called: {}", registrationId);
+        if (!REGISTRATION_ID.equals(registrationId)) {
+            return null;
+        }
+
+        // 최신 1건 조회
+        GitHubApp app = repo.findFirstByOrderByUpdatedAtDesc()
+                .orElseThrow(() -> new IllegalStateException("GitHub App이 아직 설치/연결되지 않았습니다."));
+
+        // GitHub App의 user-to-server OAuth는 OAuth Apps와 동일 엔드포인트 사용
+        return ClientRegistration.withRegistrationId(REGISTRATION_ID)
+                .clientId(app.getClientId())
+                .clientSecret(app.getClientSecret())
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .scope("read:user")
+                .authorizationUri("https://github.com/login/oauth/authorize")
+                .tokenUri("https://github.com/login/oauth/access_token")
+                .userInfoUri("https://api.github.com/user")
+                .userNameAttributeName("id")
+                .clientName("GitHub App")
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/daylily/domain/github/repository/GitHubAppRepository.java
+++ b/src/main/java/com/daylily/domain/github/repository/GitHubAppRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface GitHubAppRepository extends JpaRepository<GitHubApp, Long> {
 
     Optional<GitHubApp> findByAppId(Long appId);
+
+    Optional<GitHubApp> findFirstByOrderByUpdatedAtDesc();
 }

--- a/src/main/java/com/daylily/global/config/DynamicClientRegistrationRepository.java
+++ b/src/main/java/com/daylily/global/config/DynamicClientRegistrationRepository.java
@@ -1,7 +1,10 @@
-package com.daylily.domain.github.repository;
+package com.daylily.global.config;
 
 
 import com.daylily.domain.github.entity.GitHubApp;
+import com.daylily.domain.github.exception.GitHubErrorCode;
+import com.daylily.domain.github.exception.GitHubException;
+import com.daylily.domain.github.repository.GitHubAppRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +17,6 @@ import org.springframework.stereotype.Component;
 /**
  * DB에 저장된 GitHub App 자격증명(client_id/secret)을
  * 런타임 시 읽어 OAuth2 ClientRegistration을 동적으로 생성
- *
  * properties/.env 하드코딩 불필요
  * 최신(updatedAt DESC) 1건만 사용
  * 팀장 1명만 github_app table에 등록되는 거니까.. 걍 Spring data jpa 신경안씀
@@ -42,7 +44,7 @@ public class DynamicClientRegistrationRepository implements ClientRegistrationRe
 
         // 최신 1건 조회
         GitHubApp app = repo.findFirstByOrderByUpdatedAtDesc()
-                .orElseThrow(() -> new IllegalStateException("GitHub App이 아직 설치/연결되지 않았습니다."));
+                .orElseThrow(() -> new GitHubException(GitHubErrorCode.APP_NOT_FOUND));
 
         // GitHub App의 user-to-server OAuth는 OAuth Apps와 동일 엔드포인트 사용
         return ClientRegistration.withRegistrationId(REGISTRATION_ID)
@@ -58,7 +60,5 @@ public class DynamicClientRegistrationRepository implements ClientRegistrationRe
                 .userNameAttributeName("id")
                 .clientName("GitHub App")
                 .build();
-
     }
-
 }

--- a/src/main/java/com/daylily/global/config/SecurityConfig.java
+++ b/src/main/java/com/daylily/global/config/SecurityConfig.java
@@ -39,9 +39,14 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers(
-                                "/error",
-                                "/oauth2/authorization/**",   // 로그인 시작 엔드포인트
-                                "/login/oauth2/code/**"       // OAuth 콜백
+                                "/",
+                                "/health",
+                                "/actuator/health",
+                                "/oauth2/authorization/**",             // OAuth 로그인 시작
+                                "/login/oauth2/code/**",                // OAuth 콜백
+                                "/api/app/manifest/**",                 // GitHub App manifest redirect/convert
+                                "/api/login/oauth2/code/github-app",    // OAuth Login 경로
+                                "/api/webhook/**"                       // GitHub 웹훅 수신
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,12 +19,5 @@ springdoc.swagger-ui.path=docs
 # application host address
 app.base-url=${APP_BASE_URL}
 
-# github Oauth2 ??
-spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
-spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
-spring.security.oauth2.client.registration.github.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.github.redirect-uri=${app.base-url}/login/oauth2/code/github
-spring.security.oauth2.client.registration.github.scope=read:user,repo
-
 # jwt secret
 jwt.secret=${JWT_SECRET}


### PR DESCRIPTION
## 작업내용
- ClientRegistrationRepository를 커스텀하여 이제 더이상 Client id, secret 키를 별도로 관리하지 않아도 됩니다. 그러나, 팀 대표 1명이 미리 앱을 등록/설치 해 놓았다는 상황을 전제로 동작합니다.